### PR TITLE
Corrige dependência do libpng

### DIFF
--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -5,7 +5,7 @@ FROM php:7.1-apache
 #------------------------
 RUN apt-get update && apt-get install -y \
     libjpeg62-turbo-dev \
-    libpng12-dev \
+    libpng-dev \
     unzip \
     git \
     mysql-client \


### PR DESCRIPTION
Ao rodar o build da imagem usando o Dockerfile, o pacote **libpng12-dev** não existe mais, causando um erro no build.

Este commit resolve isso, alterando o pacote para **libpng-dev**.