### PR TITLE
Adiciona o diretório 'drush' em $PATH

### DIFF
--- a/drupal/drupal-entrypoint.sh
+++ b/drupal/drupal-entrypoint.sh
@@ -14,6 +14,8 @@ echo ""
 cd /var/www/html/
 composer install
 
+echo "export PATH=${PATH}:/var/www/html/vendor/drush/drush" >> ~/.bashrc
+
 echo ""
 echo "--------------------------------------"
 echo "------ Dependencies Installed --------"


### PR DESCRIPTION
Atualmente, para executar o comando **drush** é necessário chamar pelo seu caminho completo:
**/var/www/html/vendor/drush/drush/drush**.

Essa alteração torna global o binário do drush, tornando possível a execução do comando **drush** de qualquer diretório.